### PR TITLE
fixed typo error in stipend section (Programme setup Heading)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ European Summer of Code is a paid stipend programme.
   collaboration is virtual, via GitHub and Discord. Some partner organisations may optionally offer hybrid or in-person collaboration.
 * full time dedication to the stipend project is expected throughout the mid-year period (12 calendar weeks), excluding 5 working days of pause
 * flexible time arrangement are possible, at discretion of partner organisations - but 3 months continuous full time availability is normally expected
-* if not stated otherwise, projects are accompanied by a pro-rata based on a flat stipend of 4.800 Euro for 3 months full-time equivalent. Disbursement is via stipend through the ESoC hub.
+* if not stated otherwise, projects are accompanied by a pro-rata based on a flat stipend of 4800 Euro for 3 months full-time equivalent. Disbursement is via stipend through the ESoC hub.
 * projects may offer additional unpaid mentoring slots at their discretion.
 * participation does not constitute formal employment, nor are there delivery expectations.
 * applied projects (only those marked explicitly as "applied projects") may require signing a data sharing agreement. In this case, the agreement will be shared and can be reviewed by candidates before accepting the stipend.


### PR DESCRIPTION
A typographical error was identified in the README file under the Programme Setup heading, specifically in the Stipend section. The amount was mistakenly written as 4.8000 instead of 4800. This has now been corrected.

Fixes #55 
Closes #55
