### PR TITLE
docs: fix typo in batch card title (2025 -> 2026)

### DIFF
--- a/cards/gcos-esoc2026-batches.md
+++ b/cards/gcos-esoc2026-batches.md
@@ -1,4 +1,4 @@
-# German Center for Open Source AI - ESoC 2025 application guide
+# German Center for Open Source AI - ESoC 2026 application guide
 
 For questions about the process, please contact `info(at)gcos(dot)ai` or the [LinkedIn page for ESoC](https://www.linkedin.com/company/european-summer-of-code/)
 


### PR DESCRIPTION
"Hello Sir, noticed a small typo in the header of the gcos-esoc2026-batches.md file where it referred to 2025 instead of 2026. Updated to ensure consistency with the current program cycle."